### PR TITLE
Add configs for enabling scrolling

### DIFF
--- a/src/plugin/GridHeight.js
+++ b/src/plugin/GridHeight.js
@@ -9,14 +9,14 @@ Ext.define('Jarvus.plugin.GridHeight', {
     alias: 'plugin.gridheight',
 
     config: {
-        scrollX: false
+        enableHorizontalScroll: false
     },
 
     init: function(grid) {
         var scrollable = grid.getScrollable();
 
         scrollable.setDisabled(true);
-        scrollable.setX(this.getScrollX());
+        scrollable.setX(this.getEnableHorizontalScroll());
 
         grid.setInfinite(false);
         grid.addCls('jarvus-grid-autoheight');

--- a/src/plugin/GridHeight.js
+++ b/src/plugin/GridHeight.js
@@ -9,8 +9,7 @@ Ext.define('Jarvus.plugin.GridHeight', {
     alias: 'plugin.gridheight',
 
     config: {
-        scrollX: false,
-        scrollY: false
+        scrollX: false
     },
 
     init: function(grid) {
@@ -18,7 +17,6 @@ Ext.define('Jarvus.plugin.GridHeight', {
 
         scrollable.setDisabled(true);
         scrollable.setX(this.getScrollX());
-        scrollable.setY(this.getScrollY());
 
         grid.setInfinite(false);
         grid.addCls('jarvus-grid-autoheight');

--- a/src/plugin/GridHeight.js
+++ b/src/plugin/GridHeight.js
@@ -9,7 +9,9 @@ Ext.define('Jarvus.plugin.GridHeight', {
     alias: 'plugin.gridheight',
 
     config: {
-        enableVertical: false
+        enableVertical: false,
+        scrollX: false,
+        scrollY: false
     },
 
     init: function(grid) {
@@ -27,8 +29,8 @@ Ext.define('Jarvus.plugin.GridHeight', {
             scrollable.setDisabled(true);
         }
 
-        scrollable.setX(enableVertical);
-        scrollable.setY(false);
+        scrollable.setX(enableVertical || this.getScrollX());
+        scrollable.setY(this.getScrollY());
 
         grid.setInfinite(false);
         grid.addCls('jarvus-grid-autoheight');

--- a/src/plugin/GridHeight.js
+++ b/src/plugin/GridHeight.js
@@ -9,27 +9,15 @@ Ext.define('Jarvus.plugin.GridHeight', {
     alias: 'plugin.gridheight',
 
     config: {
-        enableVertical: false,
         scrollX: false,
         scrollY: false
     },
 
     init: function(grid) {
-        var enableVertical = this.getEnableVertical(),
-            scrollable = grid.getScrollable(),
-            container = grid.container;
+        var scrollable = grid.getScrollable();
 
-        if (enableVertical) {
-            container.hide();
-            grid.on('painted', function() {
-                grid.setWidth(grid.parent.element.getWidth())
-                container.show();
-            }, null, { single: true });
-        } else {
-            scrollable.setDisabled(true);
-        }
-
-        scrollable.setX(enableVertical || this.getScrollX());
+        scrollable.setDisabled(true);
+        scrollable.setX(this.getScrollX());
         scrollable.setY(this.getScrollY());
 
         grid.setInfinite(false);


### PR DESCRIPTION
For some reason this file is removed from the main repo. The actual changes are to add scrollX and scrollY configs. This is needed to fix an issue in the spark-classroom project, where the competencies grid uses the gridheight plugin but it wasn't resizing.
https://jarvus.atlassian.net/browse/SPARK-97
